### PR TITLE
chore: add hostname-control

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ apps:
     extensions: [gnome]
     plugs:
       - account-control
+      - hostname-control
       - timezone-control
 
 parts:


### PR DESCRIPTION
```
flutter: ERROR ubuntu_init: Unhandled exception
	DBusAccessDeniedException: org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender=":1.181" (uid=1000 pid=16123 comm="/snap/ubuntu-core-desktop-init/x1/bin/ubuntu_init" label="snap.ubuntu-core-desktop-init.ubuntu-core-desktop-init (enforce)") interface="org.freedesktop.DBus.Properties" member="Get" error name="(unset)" requested_reply="0" destination="org.freedesktop.hostname1" (bus)
```