### PR TITLE
Fix location for ubuntu-provision.conf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
     override-build: |
       set -eux
       mkdir -p $CRAFT_PART_INSTALL/bin/lib
-      cp $CRAFT_PART_SRC/assets/ubuntu-provision.conf vendor/ubuntu-desktop-provision/packages/ubuntu_init/assets/
+      cp $CRAFT_PROJECT_DIR/assets/ubuntu-provision.conf vendor/ubuntu-desktop-provision/packages/ubuntu_init/assets/
       cd vendor/ubuntu-desktop-provision/packages/ubuntu_init
       flutter pub get
       flutter build linux --release -v


### PR DESCRIPTION
This patch ensures that the ubuntu-provision.conf file used to build the snap is the one located at the 'assets' folder.