### PR TITLE
Add extra pages

### DIFF
--- a/assets/ubuntu-provision.conf
+++ b/assets/ubuntu-provision.conf
@@ -1,2 +1,2 @@
 [init]
-pages = "timezone,identity"
+pages = "keyboard,locale,timezone,identity,network"


### PR DESCRIPTION
This patch adds the extra pages required for core-desktop. All of them have been tested in a laptop, and do work fine (even the 'network' one). Thanks to these pages, it's possible to set the default language and keyboard.