### PR TITLE
Fix the password set code in ubuntu-desktop-provision

### DIFF
--- a/patches/fix_password.diff
+++ b/patches/fix_password.diff
@@ -1,0 +1,85 @@
+diff --git a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+index 3b764446..ac074fcd 100644
+--- a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
++++ b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+@@ -1,19 +1,27 @@
++import 'package:crypt/crypt.dart';
+ import 'package:dbus/dbus.dart';
++import 'package:meta/meta.dart';
+ import 'package:stdlibc/stdlibc.dart';
+ import 'package:ubuntu_provision/services.dart';
+ 
+ class XdgIdentityService implements IdentityService {
+-  XdgIdentityService({DBusClient? bus})
++  XdgIdentityService({DBusClient? bus, @visibleForTesting String? passwordSalt})
+       : _client = bus ?? DBusClient.system(),
++        _passwordSalt = passwordSalt,
+         _userId = getuid();
+ 
+-  XdgIdentityService.uid(this._userId, {DBusClient? bus})
+-      : _client = bus ?? DBusClient.system();
++  XdgIdentityService.uid(
++    this._userId, {
++    DBusClient? bus,
++    @visibleForTesting passwordSalt,
++  })  : _client = bus ?? DBusClient.system(),
++        _passwordSalt = passwordSalt;
+ 
+   static const _defaultUserId = 1000;
+ 
+   final DBusClient _client;
+   final int _userId;
++  final String? _passwordSalt;
+   Identity? _identity;
+ 
+   DBusRemoteObject get _accountObject => DBusRemoteObject(
+@@ -108,7 +116,12 @@ class XdgIdentityService implements IdentityService {
+     await userObject.callMethod(
+       'org.freedesktop.Accounts.User',
+       'SetPassword',
+-      [DBusString(_identity!.password), const DBusString('')],
++      [
++        DBusString(
++          Crypt.sha512(_identity!.password, salt: _passwordSalt).toString(),
++        ),
++        const DBusString(''),
++      ],
+       replySignature: DBusSignature.empty,
+     );
+     await userObject.callMethod(
+diff --git a/packages/ubuntu_init/pubspec.yaml b/packages/ubuntu_init/pubspec.yaml
+index 93280162..33f451d3 100644
+--- a/packages/ubuntu_init/pubspec.yaml
++++ b/packages/ubuntu_init/pubspec.yaml
+@@ -9,6 +9,7 @@ environment:
+ dependencies:
+   args: ^2.2.0
+   collection: ^1.17.0
++  crypt: ^4.3.0
+   dartx: ^1.0.0
+   dbus: ^0.7.3
+   flutter:
+diff --git a/packages/ubuntu_init/test/services/xdg_identity_service_test.dart b/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
+index d4bd7bcf..a6ce76ab 100644
+--- a/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
++++ b/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
+@@ -30,7 +30,8 @@ void main() {
+ 
+   test('apply', () async {
+     final client = createMockDBusClient();
+-    final service = XdgIdentityService.uid(0, bus: client);
++    final service =
++        XdgIdentityService.uid(0, bus: client, passwordSalt: 'testsalt');
+     await service.setIdentity(testIdentity.copyWith(password: 'password'));
+ 
+     verify(client.callMethod(
+@@ -55,7 +56,8 @@ void main() {
+       interface: 'org.freedesktop.Accounts.User',
+       name: 'SetPassword',
+       values: [
+-        const DBusString('password'),
++        const DBusString(
++            '\$6\$testsalt\$n5m85kZD9QCuizzEg/zol4HTaQ7qa9Z009rBoYAQaxBOhwiJwJsjgcZs2mwYMElypap3uDPrmdOPlLy4S28M5.'),
+         const DBusString(''),
+       ],
+       replySignature: DBusSignature.empty,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,9 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/bin/lib
       cp $CRAFT_PROJECT_DIR/assets/ubuntu-provision.conf vendor/ubuntu-desktop-provision/packages/ubuntu_init/assets/
       cp $CRAFT_PROJECT_DIR/assets/mascot.png vendor/ubuntu-desktop-provision/packages/ubuntu_init/assets/
-      cd vendor/ubuntu-desktop-provision/packages/ubuntu_init
+      cd vendor/ubuntu-desktop-provision
+      patch -p1 < $CRAFT_PROJECT_DIR/patches/fix_password.diff
+      cd packages/ubuntu_init
       # work around pub get stack overflow # https://github.com/dart-lang/sdk/issues/51068#issuecomment-1396588253
       set +e
       dart pub get


### PR DESCRIPTION
The code in ubuntu-desktop-provision has a bug in the account creation, because it presumes that the password is passed to the DBus API in plain text, when it must be passed already crypted.

This patch fixes it, while https://github.com/canonical/ubuntu-desktop-provision/pull/122 isn't merged.